### PR TITLE
Remote logging

### DIFF
--- a/src/test/java/com/karate/openwhisk/smoketests/TC04_SmokeTest_check-error-logs.feature
+++ b/src/test/java/com/karate/openwhisk/smoketests/TC04_SmokeTest_check-error-logs.feature
@@ -47,9 +47,9 @@ Feature: This feature file will test for the presence of any error in the logs p
     * def webhooks = callonce read('classpath:com/karate/openwhisk/utils/sleep.feature') {sheepCount:'20'}
     
     #Get Activation details
-    * def getActivationDetails = call read('classpath:com/karate/openwhisk/wskactions/get-activation-details.feature') { activationId: '#(actID)' ,Auth:'#(Auth)'}
-    * def activationResponse = getActivationDetails.response
-    * print activationResponse.logs
-    * match activationResponse.logs == ['#regex .* stdout: hello stdout','#regex .* stderr: hello stderr']
-    * print "Successfully pulled the activation details"
+    * def getActivationLogs = call read('classpath:com/karate/openwhisk/wskactions/get-activation-logs.feature') { activationId: '#(actID)' ,Auth:'#(Auth)'}
+    * def activationLogsResponse = getActivationLogs.response
+    * print activationLogsResponse
+    * match activationLogsResponse == ['#regex .* stdout: hello stdout','#regex .* stderr: hello stderr']
+    * print "Successfully pulled the activation logs"
     * print "TC04 ENDS"

--- a/src/test/java/com/karate/openwhisk/smoketests/TC04_SmokeTest_check-error-logs.feature
+++ b/src/test/java/com/karate/openwhisk/smoketests/TC04_SmokeTest_check-error-logs.feature
@@ -50,6 +50,6 @@ Feature: This feature file will test for the presence of any error in the logs p
     * def getActivationLogs = call read('classpath:com/karate/openwhisk/wskactions/get-activation-logs.feature') { activationId: '#(actID)' ,Auth:'#(Auth)'}
     * def activationLogsResponse = getActivationLogs.response
     * print activationLogsResponse
-    * match activationLogsResponse == ['#regex .* stdout: hello stdout','#regex .* stderr: hello stderr']
+    * match activationLogsResponse.logs contains ['#regex .* stdout: hello stdout','#regex .* stderr: hello stderr']
     * print "Successfully pulled the activation logs"
     * print "TC04 ENDS"

--- a/src/test/java/com/karate/openwhisk/wskactions/get-activation-logs.feature
+++ b/src/test/java/com/karate/openwhisk/wskactions/get-activation-logs.feature
@@ -1,0 +1,36 @@
+#/*
+ #*  Copyright 2017-2018 Adobe.
+ #*
+ #*  Licensed under the Apache License, Version 2.0 (the "License");
+ #*  you may not use this file except in compliance with the License.
+ #*  You may obtain a copy of the License at
+ #*
+ #*          http://www.apache.org/licenses/LICENSE-2.0
+ #*
+ #*  Unless required by applicable law or agreed to in writing, software
+ #*  distributed under the License is distributed on an "AS IS" BASIS,
+ #*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ #*  See the License for the specific language governing permissions and
+ #*  limitations under the License.
+ #*/
+#Author: rtripath@adobe.com
+# Summary :This feature file can be used to get action destils using action name
+@ignore
+Feature: Get Action
+
+Background:
+* configure ssl = true
+ 
+  Scenario: Get Activation Logs
+     
+#Get Activation details
+    * def path = '/api/v1/namespaces/_/activations/'+activationId+'/logs'
+    Given url BaseUrl+path
+    And header Authorization = Auth
+    And header Content-Type = 'application/json'
+    When method get
+    Then status 200
+    And def activationLogs = response
+
+   # And match response !contains {"annotations": [{"key": "initTime"}]}
+   * def webhooks = callonce read('classpath:com/karate/openwhisk/utils/sleep.js')(1000)


### PR DESCRIPTION
use `/activation/id/logs` to validate logs 