### PR TITLE
Pass provide-api-key annotation during action creation

### DIFF
--- a/src/test/java/com/karate/openwhisk/apimanagement/hit-api.feature
+++ b/src/test/java/com/karate/openwhisk/apimanagement/hit-api.feature
@@ -42,6 +42,5 @@ Feature: Hit the End Points and Assert for Success
    * match jsonResponse.env.__OW_ACTION_NAME == '#notnull'
     * match jsonResponse.env.__OW_ACTIVATION_ID == '#notnull'
      * match jsonResponse.env.__OW_API_HOST == '#notnull'
-      * match jsonResponse.env.__OW_API_KEY == '#notnull'
        * match jsonResponse.env.__OW_DEADLINE == '#notnull'
         * match jsonResponse.env.__OW_NAMESPACE == '#notnull'

--- a/src/test/java/com/karate/openwhisk/smoketests/TC01_SmokeTest_WSKFunctions.feature
+++ b/src/test/java/com/karate/openwhisk/smoketests/TC01_SmokeTest_WSKFunctions.feature
@@ -35,7 +35,7 @@ Feature: This feature file will test all the wsk functions
      # Create an Action .Create an action for the above defined guest name.The action code with invoke another action
     * print 'TC01 STARTS'
     * def createFirstAction = call read('classpath:com/karate/openwhisk/wskactions/create-action.feature') {script:'#(scriptcodefirst)' ,nameSpace:'#(nameSpace)' ,Auth:'#(Auth)',actionName:'myNestedAction'}
-    * def createSecondAction = call read('classpath:com/karate/openwhisk/wskactions/create-action.feature') {script:'#(scriptcodesecond)' ,nameSpace:'#(nameSpace)' ,Auth:'#(Auth)'}
+    * def createSecondAction = call read('classpath:com/karate/openwhisk/wskactions/create-action.feature') {script:'#(scriptcodesecond)' ,nameSpace:'#(nameSpace)' ,Auth:'#(Auth)', provideApiKey: true}
     * def actionName = createSecondAction.actName
     * print actionName
     * print "Successfully Created an action"

--- a/src/test/java/com/karate/openwhisk/wskactions/create-action.feature
+++ b/src/test/java/com/karate/openwhisk/wskactions/create-action.feature
@@ -22,7 +22,7 @@ Feature: Create an Action
   
   Background:
     * configure ssl = true
-    * def defaultPayload = {"namespace":'#(nameSpace)',"name":'#(actionName)',"exec":{"kind":"nodejs:default","code":'#(script)'},"annotations":[{"key":"web-export","value":true},{"key":"raw-http","value":false},{"key":"final","value":true}]}
+    * def defaultPayload = {"namespace":'#(nameSpace)',"name":'#(actionName)',"exec":{"kind":"nodejs:default","code":'#(script)'},"annotations":[{"key":"web-export","value":true},{"key":"raw-http","value":false},{"key":"final","value":true},{"key": "provide-api-key","value": '#(provideApiKey)'}]}
 
 
   Scenario: As a user I want to create an action
@@ -52,6 +52,15 @@ Feature: Create an Action
 					    karate.set('requestBody', defaultPayload);
 					} else {
 							karate.set('requestBody', requestBody);
+					}
+ 		 """
+
+    * eval
+ 		 """
+					if (typeof provideApiKey == 'undefined') {
+					    karate.set('provideApiKey', 'false');
+					} else {
+							karate.set('provideApiKey', provideApiKey);
 					}
  		 """
 

--- a/src/test/java/com/karate/openwhisk/wskactions/create-action.feature
+++ b/src/test/java/com/karate/openwhisk/wskactions/create-action.feature
@@ -22,7 +22,7 @@ Feature: Create an Action
   
   Background:
     * configure ssl = true
-    * def defaultPayload = {"namespace":'#(nameSpace)',"name":'#(actionName)',"exec":{"kind":"nodejs:default","code":'#(script)'},"annotations":[{"key":"web-export","value":true},{"key":"raw-http","value":false},{"key":"final","value":true},{"key": "provide-api-key","value": '#(provideApiKey)'}]}
+    * def defaultPayload = {"namespace":'#(nameSpace)',"name":'#(actionName)',"exec":{"kind":"nodejs:default","code":'#(script)'},"annotations":[{"key":"web-export","value":true},{"key":"raw-http","value":false},{"key":"final","value":true}]}
 
 
   Scenario: As a user I want to create an action
@@ -52,15 +52,6 @@ Feature: Create an Action
 					    karate.set('requestBody', defaultPayload);
 					} else {
 							karate.set('requestBody', requestBody);
-					}
- 		 """
-
-    * eval
- 		 """
-					if (typeof provideApiKey == 'undefined') {
-					    karate.set('provideApiKey', 'false');
-					} else {
-							karate.set('provideApiKey', provideApiKey);
 					}
  		 """
 

--- a/src/test/java/com/karate/openwhisk/wskactions/create-action.feature
+++ b/src/test/java/com/karate/openwhisk/wskactions/create-action.feature
@@ -22,7 +22,8 @@ Feature: Create an Action
   
   Background:
     * configure ssl = true
-    * def defaultPayload = {"namespace":'#(nameSpace)',"name":'#(actionName)',"exec":{"kind":"nodejs:default","code":'#(script)'},"annotations":[{"key":"web-export","value":true},{"key":"raw-http","value":false},{"key":"final","value":true}]}
+    * def defaultPayload = {"namespace":'#(nameSpace)',"name":'#(actionName)',"exec":{"kind":"nodejs:default","code":'#(script)'},"annotations":[{"key":"web-export","value":true},{"key":"raw-http","value":false},{"key":"final","value":true},{"key": "provide-api-key","value": '#(provideApiKey)'}]}
+
 
 
   Scenario: As a user I want to create an action
@@ -54,6 +55,16 @@ Feature: Create an Action
 							karate.set('requestBody', requestBody);
 					}
  		 """
+
+    * eval
+ 		 """
+					if (typeof provideApiKey == 'undefined') {
+					    karate.set('provideApiKey', 'false');
+					} else {
+							karate.set('provideApiKey', provideApiKey);
+					}
+ 		 """
+
 
     * string payload = requestBody
     Given url BaseUrl+'/api/v1/namespaces/'+nameSpace+'/actions/'+actionName+'?overwrite=false'


### PR DESCRIPTION
Due to changes done for [4226][1] now api key is not passed by default. So this PR changes the test setup

1. Set and pass  `provide-api-key` if needed 
2. Do not check for `__OW_API_KEY` env variable

[1]: https://github.com/apache/incubator-openwhisk/issues/4226